### PR TITLE
sensor: add `mean_type` and `unit_class` to metadata

### DIFF
--- a/homeassistant_historical_sensor/sensor.py
+++ b/homeassistant_historical_sensor/sensor.py
@@ -24,7 +24,11 @@ import sqlalchemy.exc
 import sqlalchemy.orm
 from homeassistant.components import recorder
 from homeassistant.components.recorder import db_schema
-from homeassistant.components.recorder.models import StatisticData, StatisticMetaData
+from homeassistant.components.recorder.models import (
+    StatisticData,
+    StatisticMeanType,
+    StatisticMetaData,
+)
 from homeassistant.components.recorder.statistics import (
     async_add_external_statistics,
     async_import_statistics,
@@ -372,7 +376,10 @@ class HistoricalSensor(SensorEntity):
             source = "recorder"
 
         metadata = StatisticMetaData(
+            # has_mean will get remmoved in 2026.4 [0].
+            # [0] https://github.com/home-assistant/core/blob/f3ddffb5ffe40627d7809e8911a4948f418e6472/homeassistant/components/recorder/models/statistics.py#L66-L68
             has_mean=False,
+            mean_type=StatisticMeanType.NONE,
             has_sum=False,
             name=f"{self.name} Statistics",
             source=source,

--- a/homeassistant_historical_sensor/sensor.py
+++ b/homeassistant_historical_sensor/sensor.py
@@ -384,6 +384,7 @@ class HistoricalSensor(SensorEntity):
             name=f"{self.name} Statistics",
             source=source,
             statistic_id=self.statistic_id,
+            unit_class=None,
             unit_of_measurement=self.unit_of_measurement,
         )
 


### PR DESCRIPTION
This fixes deprecation issues with 2025.11.

fixes: ldotlopez/ha-historical-sensor#16
